### PR TITLE
Fixed #2 Issue of make return error for gcc - version > 5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-O3 -g -march=native -Wall -Wextra
+CFLAGS=-O3 -g -march=native -Wall -Wextra -std=gnu89
 LDFLAGS=
 
 .PHONY: all trace doc clean


### PR DESCRIPTION
so there is a problem in semantic of inline for gcc -version >5.0.
we have to use the flag -std=gnu89 or you could change the semantic of inline from "__inline__" to "extern __inline__"